### PR TITLE
Updated getJobClasses to use cascading resource loader

### DIFF
--- a/src/main/java/org/quartz/classloading/CascadingClassLoadHelper.java
+++ b/src/main/java/org/quartz/classloading/CascadingClassLoadHelper.java
@@ -212,7 +212,7 @@ public class CascadingClassLoadHelper implements ClassLoadHelper {
     String relPath = pkgname.replace('.', '/');
 
     // Get a File object for the package
-    URL resource = ClassLoader.getSystemClassLoader().getResource(relPath);
+    URL resource = getResource(relPath);
     if (resource == null) {
       throw new RuntimeException("Unexpected problem: No resource for " + relPath);
     }


### PR DESCRIPTION
SystemClassLoader does not work inside of a WAR. This uses the CascadingClassLoadHelper's getResource implementation to pull the correct resource.