### PR TITLE
Let trigger builder methods be called in any order

### DIFF
--- a/src/main/java/org/quartz/builders/CronTriggerBuilder.java
+++ b/src/main/java/org/quartz/builders/CronTriggerBuilder.java
@@ -18,8 +18,10 @@
 package org.quartz.builders;
 
 import java.text.ParseException;
+import java.util.Date;
 import java.util.TimeZone;
 
+import org.quartz.jobs.JobDataMap;
 import org.quartz.triggers.CronExpression;
 import org.quartz.triggers.CronTrigger;
 import org.quartz.triggers.CronTriggerImpl;
@@ -134,5 +136,41 @@ public class CronTriggerBuilder extends TriggerBuilder {
 
     misfireInstruction = CronTrigger.MISFIRE_INSTRUCTION_FIRE_ONCE_NOW;
     return this;
+  }
+
+  public CronTriggerBuilder withIdentity(String name) {
+    return (CronTriggerBuilder)super.withIdentity(name);
+  }
+
+  public CronTriggerBuilder withDescription(String description) {
+    return (CronTriggerBuilder)super.withDescription(description);
+  }
+
+  public CronTriggerBuilder withPriority(int priority) {
+    return (CronTriggerBuilder)super.withPriority(priority);
+  }
+
+  public CronTriggerBuilder modifiedByCalendar(String calendarName) {
+    return (CronTriggerBuilder)super.modifiedByCalendar(calendarName);
+  }
+
+  public CronTriggerBuilder startNow() {
+    return (CronTriggerBuilder)super.startNow();
+  }
+
+  public CronTriggerBuilder startAt(Date startTime) {
+    return (CronTriggerBuilder)super.startAt(startTime);
+  }
+
+  public CronTriggerBuilder endAt(Date endTime) {
+    return (CronTriggerBuilder)super.endAt(endTime);
+  }
+
+  public CronTriggerBuilder forJob(String jobName) {
+    return (CronTriggerBuilder)super.forJob(jobName);
+  }
+
+  public CronTriggerBuilder usingJobData(JobDataMap newJobDataMap) {
+    return (CronTriggerBuilder)super.usingJobData(newJobDataMap);
   }
 }

--- a/src/main/java/org/quartz/builders/SimpleTriggerBuilder.java
+++ b/src/main/java/org/quartz/builders/SimpleTriggerBuilder.java
@@ -16,6 +16,9 @@
  */
 package org.quartz.builders;
 
+import java.util.Date;
+
+import org.quartz.jobs.JobDataMap;
 import org.quartz.triggers.OperableTrigger;
 import org.quartz.triggers.SimpleTrigger;
 import org.quartz.triggers.SimpleTriggerImpl;
@@ -176,4 +179,39 @@ public class SimpleTriggerBuilder extends TriggerBuilder {
     return this;
   }
 
+  public SimpleTriggerBuilder withIdentity(String name) {
+    return (SimpleTriggerBuilder)super.withIdentity(name);
+  }
+
+  public SimpleTriggerBuilder withDescription(String description) {
+    return (SimpleTriggerBuilder)super.withDescription(description);
+  }
+
+  public SimpleTriggerBuilder withPriority(int priority) {
+    return (SimpleTriggerBuilder)super.withPriority(priority);
+  }
+
+  public SimpleTriggerBuilder modifiedByCalendar(String calendarName) {
+    return (SimpleTriggerBuilder)super.modifiedByCalendar(calendarName);
+  }
+
+  public SimpleTriggerBuilder startNow() {
+    return (SimpleTriggerBuilder)super.startNow();
+  }
+
+  public SimpleTriggerBuilder startAt(Date startTime) {
+    return (SimpleTriggerBuilder)super.startAt(startTime);
+  }
+
+  public SimpleTriggerBuilder endAt(Date endTime) {
+    return (SimpleTriggerBuilder)super.endAt(endTime);
+  }
+
+  public SimpleTriggerBuilder forJob(String jobName) {
+    return (SimpleTriggerBuilder)super.forJob(jobName);
+  }
+
+  public SimpleTriggerBuilder usingJobData(JobDataMap newJobDataMap) {
+    return (SimpleTriggerBuilder)super.usingJobData(newJobDataMap);
+  }
 }

--- a/src/test/java/org/quartz/builders/CronTriggerBuilderTest.java
+++ b/src/test/java/org/quartz/builders/CronTriggerBuilderTest.java
@@ -1,0 +1,30 @@
+package org.quartz.builders;
+
+import java.text.ParseException;
+import java.util.Date;
+import java.util.TimeZone;
+import org.junit.Test;
+import org.quartz.jobs.JobDataMap;
+import org.quartz.builders.CronTriggerBuilder;
+import org.quartz.triggers.OperableTrigger;
+
+public class CronTriggerBuilderTest {
+  @Test
+  public void shouldBeAbleToCallMethodsInAnyOrder() throws ParseException {
+    OperableTrigger trigger = CronTriggerBuilder
+      .cronTriggerBuilder("0/5 * * * * ?")
+      .withIdentity("id")
+      .withDescription("description")
+      .withPriority(1)
+      .modifiedByCalendar("foo")
+      .startNow()
+      .startAt(new Date())
+      .endAt(new Date())
+      .forJob("job1")
+      .usingJobData(new JobDataMap())
+      .inTimeZone(TimeZone.getDefault())
+      .withMisfireHandlingInstructionDoNothing()
+      .withMisfireHandlingInstructionFireAndProceed()
+      .build();
+  }
+}

--- a/src/test/java/org/quartz/builders/SimpleTriggerBuilderTest.java
+++ b/src/test/java/org/quartz/builders/SimpleTriggerBuilderTest.java
@@ -1,0 +1,32 @@
+package org.quartz.builders;
+
+import java.util.Date;
+import org.junit.Test;
+import org.quartz.jobs.JobDataMap;
+import org.quartz.builders.SimpleTriggerBuilder;
+import org.quartz.triggers.OperableTrigger;
+
+public class SimpleTriggerBuilderTest {
+  @Test
+  public void shouldBeAbleToCallMethodsInAnyOrder() {
+    OperableTrigger trigger = SimpleTriggerBuilder.simpleTriggerBuilder()
+      .withIdentity("id")
+      .withDescription("description")
+      .withPriority(1)
+      .modifiedByCalendar("foo")
+      .startNow()
+      .startAt(new Date())
+      .endAt(new Date())
+      .forJob("job1")
+      .usingJobData(new JobDataMap())
+      .withIntervalInMilliseconds(1000)
+      .withRepeatCount(10)
+      .repeatForever()
+      .withMisfireHandlingInstructionFireNow()
+      .withMisfireHandlingInstructionNextWithExistingCount()
+      .withMisfireHandlingInstructionNextWithRemainingCount()
+      .withMisfireHandlingInstructionNowWithExistingCount()
+      .withMisfireHandlingInstructionNowWithRemainingCount()
+      .build();
+  }
+}


### PR DESCRIPTION
Would be cleaner using something like

    public class SimpleTriggerBuilder extends TriggerBuilder<SimpleTriggerBuilder> {
      // ...
    }
    
    public abstract class TriggerBuilder<T extends TriggerBuilder> {
      // ...
      public T withIdentity(String name) {
        // ...
      }
      // ...
    }

but I can't think of a way to do that that is 100% API compatible.