### PR TITLE
Make usable SundialJobScheduler after shoutdown

### DIFF
--- a/src/main/java/org/knowm/sundial/SundialJobScheduler.java
+++ b/src/main/java/org/knowm/sundial/SundialJobScheduler.java
@@ -526,6 +526,7 @@ public class SundialJobScheduler {
 
     try {
       getScheduler().shutdown(true);
+      scheduler = null;
     } catch (Exception e) {
       throw new SundialSchedulerException("COULD NOT SHUTDOWN SCHEDULER!!!", e);
     }


### PR DESCRIPTION
When we do restore application we may call `SundialJobScheduler.shutdown();` after completed restore operation we will start scheduler again. But current design not allowing to start scheduler after shutdown `SundialJobScheduler.startScheduler();` as `scheduler` referring old reference.

To resolve this, whenever shutdown called assign `scheduler = null`.