### PR TITLE
Improved error logging when jobs fail

### DIFF
--- a/src/main/java/org/knowm/sundial/Job.java
+++ b/src/main/java/org/knowm/sundial/Job.java
@@ -58,7 +58,11 @@ public abstract class Job extends JobContainer implements InterruptableJob {
     } catch (RequiredParameterException e) {
     } catch (JobInterruptException e) {
     } catch (Exception e) {
-      logger.error("Error executing Job! Job aborted!!!", e);
+      logger.error(String.format(
+              "Job [%s] aborted due to execution error: %s",
+              jobExecutionContext.getJobDetail().getName(),
+              e.getMessage())
+              , e);
     } finally {
       cleanup();
       destroyContext(); // remove the JobContext from the ThreadLocal

--- a/src/test/java/org/knowm/sundial/BadJobTest.java
+++ b/src/test/java/org/knowm/sundial/BadJobTest.java
@@ -38,6 +38,5 @@ public class BadJobTest {
         SundialJobScheduler.addSimpleTrigger("bj-trigger", BadJob.class.getSimpleName(), 1,1);
         List<String> names = SundialJobScheduler.getAllJobNames();
         Thread.sleep(100);
-        SundialJobScheduler.getScheduler().shutdown(true);
     }
 }

--- a/src/test/java/org/knowm/sundial/BadJobTest.java
+++ b/src/test/java/org/knowm/sundial/BadJobTest.java
@@ -35,7 +35,7 @@ public class BadJobTest {
     public void testJobsNeverFail() throws InterruptedException, SchedulerException {
         BadJob bj = new BadJob();
         SundialJobScheduler.addJob(BadJob.class.getSimpleName(), BadJob.class);
-        SundialJobScheduler.addSimpleTrigger("bj-trigger", BadJob.class.getSimpleName(), 1,1);
+        SundialJobScheduler.addSimpleTrigger("bj-trigger", BadJob.class.getSimpleName(), 0,1);
         List<String> names = SundialJobScheduler.getAllJobNames();
         Thread.sleep(100);
     }

--- a/src/test/java/org/knowm/sundial/BadJobTest.java
+++ b/src/test/java/org/knowm/sundial/BadJobTest.java
@@ -1,0 +1,43 @@
+package org.knowm.sundial;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.knowm.sundial.exceptions.JobInterruptException;
+import org.quartz.core.SchedulerFactory;
+import org.quartz.exceptions.SchedulerException;
+
+import java.util.List;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * This doesn't really test much. But at least it allows us to inspect the job output on errors.
+ */
+public class BadJobTest {
+    public static class BadJob extends Job {
+
+        @Override
+        public void doRun() throws JobInterruptException {
+            throw new RuntimeException("I'm bad to the bone");
+        }
+    }
+
+    @Before
+    public void setup() {
+        SundialJobScheduler.startScheduler(1, null); //null -> don't load anything
+        List<String> names = SundialJobScheduler.getAllJobNames();
+
+        //We get the jobs from the XML for free
+        //assertTrue( names.isEmpty() );
+    }
+
+    @Test
+    public void testJobsNeverFail() throws InterruptedException, SchedulerException {
+        BadJob bj = new BadJob();
+        SundialJobScheduler.addJob(BadJob.class.getSimpleName(), BadJob.class);
+        SundialJobScheduler.addSimpleTrigger("bj-trigger", BadJob.class.getSimpleName(), 1,1);
+        List<String> names = SundialJobScheduler.getAllJobNames();
+        Thread.sleep(100);
+        SundialJobScheduler.getScheduler().shutdown(true);
+    }
+}


### PR DESCRIPTION
We found the log messages (used to generate some automated alerts in our system) weren't useful. This should improve things.